### PR TITLE
Allow specification of font

### DIFF
--- a/src/graphics/context/canvas.rs
+++ b/src/graphics/context/canvas.rs
@@ -229,8 +229,8 @@ impl CanvasContext {
 
     pub fn measure_label(&self, label: &str, font: Option<&str>) -> Vector2<f32> {
         self.canvas.save();
-        if font.is_some() {
-            self.canvas.set_font(font.unwrap());
+        if let Some(f) = font {
+            self.canvas.set_font(f);
         }
         self.canvas.set_text_align(TextAlign::Left);
         self.canvas.set_text_baseline(TextBaseline::Hanging);

--- a/src/graphics/context/canvas.rs
+++ b/src/graphics/context/canvas.rs
@@ -4,6 +4,7 @@ use stdweb::{
 };
 
 use crate::goodies::matrix_transform_2d::*;
+use crate::graphics::text::Font;
 use crate::graphics::types::Rect;
 
 use cgmath::{EuclideanSpace, InnerSpace, Matrix3, Point2, Vector2};
@@ -204,8 +205,8 @@ impl CanvasContext {
         if let Some(color) = color {
             self.canvas.set_fill_style_color(color);
         }
-        if font.is_some() {
-            self.canvas.set_font(font.unwrap());
+        if let Some(f) = font {
+            self.canvas.set_font(f);
         }
 
         self.canvas.set_text_align(TextAlign::Left);

--- a/src/graphics/context/canvas.rs
+++ b/src/graphics/context/canvas.rs
@@ -4,7 +4,6 @@ use stdweb::{
 };
 
 use crate::goodies::matrix_transform_2d::*;
-use crate::graphics::text::Font;
 use crate::graphics::types::Rect;
 
 use cgmath::{EuclideanSpace, InnerSpace, Matrix3, Point2, Vector2};

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Font {}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Font(String);
 
 impl Font {
-    pub fn new(_: &mut Context, _: &str) -> GameResult<Font> {
-        Ok(Font {})
+    pub fn new(_: &mut Context, font: &str) -> GameResult<Font> {
+        Ok(Font(font.to_owned()))
     }
 }
 

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -28,7 +28,7 @@ impl Scale {
 /// A piece of text with optional color, font and font scale information.
 /// Drawing text generally involves one or more of these.
 /// These options take precedence over any similar field/argument.
-/// Can be implicitly constructed from `String`, `(String, Color)`, and `(String, FontId, Scale)`.
+/// Can be implicitly constructed from `String`, `(String, Color)`, and `(String, Font, Scale)`.
 #[derive(Clone, Debug)]
 pub struct TextFragment {
     /// Text string itself.
@@ -151,7 +151,7 @@ impl Drawable for Text {
             &self.fragment.text,
             param.dest,
             Some(param.scale),
-            None,
+            self.fragment.font.as_ref().map(|x| &*x.0),
             Some(&Into::<String>::into(param.color)),
         );
         Ok(())

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Font(String);
+pub struct Font(pub String);
 
 impl Font {
     pub fn new(_: &mut Context, font: &str) -> GameResult<Font> {


### PR DESCRIPTION
Greetings!

This changeset allows for font selection.  It doesn't introduce any sort of fine-grained data type which deals with `font-style`, `font-variant`, etc directly -- instead, we opted for a simple string.  Given that the [HTML canvas font property uses a simple string](https://www.w3schools.com/tags/canvas_font.asp), we hope that this is an adequate approach.

You can see this in action [in our humble pong clone](https://pong.prawn.farm/), at least for the time being.  We used `small-caps 10px Courier New` to change the font.

[Example of the Font API call](https://github.com/Terkwood/rust-wasm-pong/blob/9bc5d4f060a293dad7d9c0621f529aa4e6535653/src/state.rs#L239)

![Screen Shot 2019-03-12 at 2 06 09 PM](https://user-images.githubusercontent.com/38859656/54224769-98dcbc00-44d0-11e9-8179-50a04d0a5db3.png)

Please let us know if you'd like any changes.  Thank you! 🙇