### PR TITLE
SpriteBatch, FilterMode and src/offset

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -5,6 +5,8 @@ mod shader;
 mod text;
 mod types;
 
+pub mod spritebatch;
+
 use crate::error::GameResult;
 use crate::Context;
 
@@ -116,4 +118,22 @@ pub trait Drawable {
     fn dimensions(&self, _: &mut Context) -> Option<Rect> {
         None
     }
+}
+
+/// Applies `DrawParam` to `Rect`.
+pub fn transform_rect(rect: Rect, param: DrawParam) -> Rect {
+    let w = param.src.w * param.scale.x * rect.w;
+    let h = param.src.h * param.scale.y * rect.h;
+    let offset_x = w * param.offset.x;
+    let offset_y = h * param.offset.y;
+    let dest_x = param.dest.x - offset_x;
+    let dest_y = param.dest.y - offset_y;
+    let mut r = Rect {
+        w,
+        h,
+        x: dest_x + rect.x * param.scale.x,
+        y: dest_y + rect.y * param.scale.y,
+    };
+    r.rotate(param.rotation);
+    r
 }

--- a/src/graphics/context/canvas.rs
+++ b/src/graphics/context/canvas.rs
@@ -62,8 +62,6 @@ impl CanvasContext {
     }
 
     pub fn set_screen_coordinates(&mut self, rect: Rect) {
-        use cgmath::Matrix3;
-
         let (width, height) = self.size();
         let translate = Matrix3::from_translation(Vector2::new(-rect.x, -rect.y));
         let scale = Matrix3::from_nonuniform_scale(width as f32 / rect.w, height as f32 / rect.h);

--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -1,0 +1,97 @@
+use crate::{
+    error::GameResult,
+    graphics::{self, transform_rect, BlendMode, Rect, DrawParam},
+    Context,
+};
+
+#[derive(Debug, Clone)]
+pub struct SpriteBatch {
+    image: graphics::Image,
+    sprites: Vec<graphics::DrawParam>,
+    blend_mode: Option<BlendMode>,
+}
+
+/// An index of a particular sprite in a `SpriteBatch`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpriteIdx(usize);
+
+impl SpriteBatch {
+    /// Creates a new `SpriteBatch`, drawing with the given image.
+    ///
+    /// Takes ownership of the `Image`, but cloning an `Image` is
+    /// cheap since they have an internal `Arc` containing the actual
+    /// image data.
+    pub fn new(image: graphics::Image) -> Self {
+        Self {
+            image,
+            sprites: vec![],
+            blend_mode: None,
+        }
+    }
+
+    /// Adds a new sprite to the sprite batch.
+    ///
+    /// Returns a handle with which type to modify the sprite using
+    /// [`set()`](#method.set)
+    pub fn add<P>(&mut self, param: P) -> SpriteIdx
+    where
+        P: Into<graphics::DrawParam>,
+    {
+        self.sprites.push(param.into());
+        SpriteIdx(self.sprites.len() - 1)
+    }
+
+    /// Removes all data from the sprite batch.
+    pub fn clear(&mut self) {
+        self.sprites.clear();
+    }
+
+    /// Unwraps and returns the contained `Image`
+    pub fn into_inner(self) -> graphics::Image {
+        self.image
+    }
+}
+
+impl graphics::Drawable for SpriteBatch {
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
+        // TODO: This is really nasty and doesn't really do the batching
+        for &sprite_param in self.sprites.iter() {
+            let mut new_param = sprite_param.clone();
+
+            new_param.dest.x = new_param.dest.x * param.scale.x + param.dest.x;
+            new_param.dest.y = new_param.dest.y * param.scale.y + param.dest.y;
+            new_param.scale.x *= param.scale.x;
+            new_param.scale.y *= param.scale.y;
+
+            graphics::draw(ctx, &self.image, new_param)?;
+        }
+
+        Ok(())
+    }
+
+    fn dimensions(&self, _ctx: &mut Context) -> Option<Rect> {
+        if self.sprites.is_empty() {
+            return None;
+        }
+        let dimensions = self.image.dimensions();
+        self.sprites
+            .iter()
+            .map(|&param| transform_rect(dimensions, param))
+            .fold(None, |acc: Option<Rect>, rect| {
+                Some(if let Some(acc) = acc {
+                    acc.combine_with(rect)
+                } else {
+                    rect
+                })
+            })
+    }
+
+    fn set_blend_mode(&mut self, mode: Option<BlendMode>) {
+        // TODO
+        self.blend_mode = mode;
+    }
+
+    fn blend_mode(&self) -> Option<BlendMode> {
+        self.blend_mode
+    }
+}

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -122,6 +122,49 @@ impl Rect {
         self.w *= sx;
         self.h *= sy;
     }
+
+    /// Returns a new `Rect` that includes all points of these two `Rect`s.
+    pub fn combine_with(self, other: Rect) -> Rect {
+        let x = f32::min(self.x, other.x);
+        let y = f32::min(self.y, other.y);
+        let w = f32::max(self.right(), other.right()) - x;
+        let h = f32::max(self.bottom(), other.bottom()) - y;
+        Rect { x, y, w, h }
+    }
+
+    /// Calculated the new Rect around the rotated one.
+    pub fn rotate(&mut self, rotation: f32) {
+        use cgmath::{Basis2, Rotation, Rotation2};
+
+        let rotation: Basis2<f32> = Rotation2::from_angle(cgmath::Rad(rotation));
+        let x0 = self.x;
+        let y0 = self.y;
+        let x1 = self.right();
+        let y1 = self.bottom();
+        let points = [
+            rotation.rotate_point(cgmath::Point2::new(x0, y0)),
+            rotation.rotate_point(cgmath::Point2::new(x0, y1)),
+            rotation.rotate_point(cgmath::Point2::new(x1, y0)),
+            rotation.rotate_point(cgmath::Point2::new(x1, y1)),
+        ];
+        let p0 = points[0];
+        let mut x_max = p0.x;
+        let mut x_min = p0.x;
+        let mut y_max = p0.y;
+        let mut y_min = p0.y;
+        for p in &points {
+            x_max = f32::max(x_max, p.x);
+            x_min = f32::min(x_min, p.x);
+            y_max = f32::max(y_max, p.y);
+            y_min = f32::min(y_min, p.y);
+        }
+        *self = Rect {
+            w: x_max - x_min,
+            h: y_max - y_min,
+            x: x_min,
+            y: y_min,
+        }
+    }
 }
 
 impl From<[f32; 4]> for Rect {


### PR DESCRIPTION
Added couple of things:

+ `SpriteBatch` compatible with ggez. It's working, although it's actually not batching anything, so room for improvement here!
+ `FilterMode` for `Image` via `set_filter`. Works as intended, although I'm not particularly fond of having to use a dirty boolean flag, so this also can be done better.
+ The `src` on `DrawParam` actually works now. I'd appreciate if someone actually looked at what I did here as this was first time in my life I touched GLSL :P.
+ Fixed `scale` and `offset` on `DrawParam`.

I hope I haven't broken anything in Zemeroth with this :sweat_smile:. I've uploaded a [demo video](https://twitter.com/MaciejHirsz/status/1136699493771030535) of what I'm building, all sprite animations and font rendering is done via atlases, so `src` not working broke things horribly.