### PR TITLE
Canvas API

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -31,3 +31,20 @@ pub struct Conf {
     #[default(Loading::No)]
     pub loading: Loading,
 }
+
+/// The possible number of samples for multisample anti-aliasing.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NumSamples {
+    /// Multisampling disabled.
+    Zero = 0,
+    /// One sample
+    One = 1,
+    /// Two samples
+    Two = 2,
+    /// Four samples
+    Four = 4,
+    /// Eight samples
+    Eight = 8,
+    /// Sixteen samples
+    Sixteen = 16,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub enum GameError {
     /// Something went wrong trying to read from a file
     IOError(std::io::Error),
-    UnknownError(String),
+    UnknownError(&'static str),
 }
 
 impl fmt::Display for GameError {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -4,6 +4,7 @@ mod image;
 mod shader;
 mod text;
 mod types;
+mod canvas;
 
 pub mod spritebatch;
 
@@ -16,6 +17,10 @@ pub use self::{
         canvas::*,
         webgl::{ShaderObject, Uniform, WebGlContext},
         GraphicsContext,
+    },
+    canvas::{
+        Canvas,
+        set_canvas,
     },
     drawparam::DrawParam,
     image::*,

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -1,0 +1,74 @@
+use crate::{
+    Context,
+    GameResult,
+    conf::NumSamples,
+    error::GameError,
+    graphics::{Drawable, DrawParam, Rect, BlendMode, Image, context::webgl::{Texture, Framebuffer}},
+};
+
+pub struct Canvas {
+    image: Image,
+    framebuffer: Framebuffer,
+}
+
+impl Canvas {
+    pub fn new(
+        ctx: &mut Context,
+        width: u16,
+        height: u16,
+        samples: NumSamples
+    ) -> GameResult<Canvas> {
+        let texture = Texture::from_rgba8(ctx, width, height, None);
+        let framebuffer = Framebuffer::new(ctx, &texture)
+                            .ok_or_else(|| GameError::UnknownError("Couldn't create a Framebuffer"))?;
+        let image = Image::from_texture(width, height, Some(texture));
+
+        Ok(Canvas {
+            image,
+            framebuffer,
+        })
+    }
+
+    fn dimensions(&self) -> Rect {
+        self.image.dimensions()
+    }
+}
+
+impl Drawable for Canvas {
+    fn draw(&self, ctx: &mut Context, param: DrawParam) -> GameResult {
+        self.image.draw(ctx, param)
+    }
+
+    fn set_blend_mode(&mut self, blend_mode: Option<BlendMode>) {
+        self.image.set_blend_mode(blend_mode);
+    }
+
+    fn blend_mode(&self) -> Option<BlendMode> {
+        self.image.blend_mode()
+    }
+
+    fn dimensions(&self, _: &mut Context) -> Option<Rect> {
+        Some(self.dimensions())
+    }
+}
+
+/// Set the `Canvas` to render to. Specifying `Option::None` will cause all
+/// rendering to be done directly to the screen.
+pub fn set_canvas(ctx: &mut Context, target: Option<&Canvas>) {
+    let (width, height) = target.map(|canvas| {
+        // Use dimensions of the image bound to framebuffer
+        let rect = canvas.dimensions();
+
+        (rect.w as u32, rect.h as u32)
+    }).unwrap_or_else(|| {
+        // Use original dimensions of the webgl canvas context
+        let (width, height) = ctx.gfx_context.canvas_context.size();
+
+        (width as u32, height as u32)
+    });
+
+    let webgl = &mut ctx.gfx_context.webgl_context;
+
+    webgl.set_framebuffer(target.map(|canvas| &canvas.framebuffer));
+    webgl.resize(width, height);
+}

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -60,10 +60,6 @@ impl Canvas {
         // than the default; does that matter?
         self.image
     }
-
-    fn dimensions(&self) -> Rect {
-        self.image.dimensions()
-    }
 }
 
 impl Drawable for Canvas {
@@ -85,7 +81,7 @@ impl Drawable for Canvas {
     }
 
     fn dimensions(&self, _: &mut Context) -> Option<Rect> {
-        Some(self.dimensions())
+        Some(self.image.dimensions())
     }
 }
 
@@ -94,7 +90,7 @@ impl Drawable for Canvas {
 pub fn set_canvas(ctx: &mut Context, target: Option<&Canvas>) {
     let (width, height) = target.map(|canvas| {
         // Use dimensions of the image bound to framebuffer
-        let rect = canvas.dimensions();
+        let rect = canvas.image().dimensions();
 
         (rect.w as u32, rect.h as u32)
     }).unwrap_or_else(|| {

--- a/src/graphics/context/webgl.rs
+++ b/src/graphics/context/webgl.rs
@@ -27,7 +27,7 @@ impl Texture {
         let gl_ctx = &mut context.gfx_context.webgl_context.gl_ctx;
 
         let texture = gl_ctx.create_texture().unwrap();
-        // gl_ctx.active_texture(gl::TEXTURE0);
+        gl_ctx.active_texture(gl::TEXTURE0);
         gl_ctx.bind_texture(gl::TEXTURE_2D, Some(&texture));
         gl_ctx.tex_image2_d_1(
             gl::TEXTURE_2D,

--- a/src/graphics/context/webgl.rs
+++ b/src/graphics/context/webgl.rs
@@ -261,9 +261,8 @@ impl WebGlContext {
         let projection = cgmath::One::one();
         let screen_rect = Rect::new(-1., -1., 2., 2.);
 
-        gl_ctx.color_mask(true, true, true, false);
         gl_ctx.enable(gl::BLEND);
-        gl_ctx.blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+        gl_ctx.blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::ONE, gl::ONE_MINUS_SRC_ALPHA);
 
         gl_ctx.bind_buffer(gl::ARRAY_BUFFER, Some(&quad));
 

--- a/src/graphics/context/webgl.rs
+++ b/src/graphics/context/webgl.rs
@@ -3,7 +3,7 @@ use stdweb::{unstable::*, web::html_element::*, web::*};
 use cgmath::{Matrix4, Point2, Vector2, Vector3, Vector4, Rad};
 use webgl_stdweb::{
     GLenum, WebGLBuffer, WebGLProgram, WebGLRenderingContext, WebGLRenderingContext as gl,
-    WebGLShader, WebGLTexture, WebGLUniformLocation,
+    WebGLShader, WebGLTexture, WebGLUniformLocation, WebGLFramebuffer,
 };
 
 use crate::graphics::types::{Color, Rect};
@@ -27,7 +27,7 @@ impl Texture {
         let gl_ctx = &mut context.gfx_context.webgl_context.gl_ctx;
 
         let texture = gl_ctx.create_texture().unwrap();
-        gl_ctx.active_texture(gl::TEXTURE0);
+        // gl_ctx.active_texture(gl::TEXTURE0);
         gl_ctx.bind_texture(gl::TEXTURE_2D, Some(&texture));
         gl_ctx.tex_image2_d_1(
             gl::TEXTURE_2D,
@@ -49,7 +49,7 @@ impl Texture {
         context: &mut crate::Context,
         width: u16,
         height: u16,
-        bytes: &[u8],
+        bytes: Option<&[u8]>,
     ) -> Texture {
         let gl_ctx = &context.gfx_context.webgl_context.gl_ctx;
 
@@ -60,7 +60,7 @@ impl Texture {
         gl_ctx: &WebGLRenderingContext,
         width: u16,
         height: u16,
-        bytes: &[u8],
+        bytes: Option<&[u8]>,
     ) -> Texture {
         let texture = gl_ctx.create_texture().unwrap();
         gl_ctx.active_texture(gl::TEXTURE0);
@@ -74,7 +74,7 @@ impl Texture {
             0,
             gl::RGBA,
             gl::UNSIGNED_BYTE,
-            Some(bytes),
+            bytes,
         );
         gl_ctx.tex_parameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as i32);
         gl_ctx.tex_parameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
@@ -90,6 +90,28 @@ impl Texture {
 
         gl_ctx.tex_parameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, filter);
         gl_ctx.tex_parameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, filter);
+    }
+}
+
+pub struct Framebuffer {
+    fb: WebGLFramebuffer,
+}
+
+impl Framebuffer {
+    pub fn new(context: &mut crate::Context, texture: &Texture) -> Option<Framebuffer> {
+        let gl_ctx = &mut context.gfx_context.webgl_context.gl_ctx;
+
+        let tex = &texture.texture;
+        let fb = gl_ctx.create_framebuffer()?;
+
+        gl_ctx.bind_texture(gl::TEXTURE_2D, Some(tex));
+        gl_ctx.bind_framebuffer(gl::FRAMEBUFFER, Some(&fb));
+        gl_ctx.framebuffer_texture2_d(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, Some(tex), 0);
+        gl_ctx.bind_framebuffer(gl::FRAMEBUFFER, None);
+
+        Some(Framebuffer {
+            fb
+        })
     }
 }
 
@@ -272,6 +294,10 @@ impl WebGlContext {
 
     pub(crate) fn resize(&self, w: u32, h: u32) {
         self.gl_ctx.viewport(0, 0, w as i32, h as i32);
+    }
+
+    pub(crate) fn set_framebuffer(&self, fb: Option<&Framebuffer>) {
+        self.gl_ctx.bind_framebuffer(gl::FRAMEBUFFER, fb.map(|fb| &fb.fb));
     }
 
     pub fn draw_image(

--- a/src/graphics/types.rs
+++ b/src/graphics/types.rs
@@ -241,39 +241,31 @@ impl Color {
 
     /// Convert a packed `u32` containing `0xRRGGBBAA` into a `Color`
     pub fn from_rgba_u32(c: u32) -> Color {
-        let rp = ((c & 0xFF00_0000u32) >> 24) as u8;
-        let gp = ((c & 0x00FF_0000u32) >> 16) as u8;
-        let bp = ((c & 0x0000_FF00u32) >> 8) as u8;
-        let ap = (c & 0x0000_00FFu32) as u8;
-        Color::from((rp, gp, bp, ap))
+        let c = c.to_be_bytes();
+
+        Color::from((c[0], c[1], c[2], c[3]))
     }
 
     /// Convert a packed `u32` containing `0x00RRGGBB` into a `Color`.
     /// This lets you do things like `Color::from_rgb_u32(0xCD09AA)` easily if you want.
     pub fn from_rgb_u32(c: u32) -> Color {
-        let rp = ((c & 0x00FF_0000u32) >> 16) as u8;
-        let gp = ((c & 0x0000_FF00u32) >> 8) as u8;
-        let bp = (c & 0x0000_00FFu32) as u8;
-        Color::from((rp, gp, bp))
+        let c = c.to_be_bytes();
+
+        Color::from((c[1], c[2], c[3]))
     }
 
     /// Convert a `Color` into a packed `u32`, containing `0xRRGGBBAA` as bytes.
     pub fn to_rgba_u32(self) -> u32 {
         let (r, g, b, a): (u8, u8, u8, u8) = self.into();
-        let rp = (u32::from(r)) << 24;
-        let gp = (u32::from(g)) << 16;
-        let bp = (u32::from(b)) << 8;
-        let ap = u32::from(a);
-        (rp | gp | bp | ap)
+
+        u32::from_be_bytes([r, g, b, a])
     }
 
     /// Convert a `Color` into a packed `u32`, containing `0x00RRGGBB` as bytes.
     pub fn to_rgb_u32(self) -> u32 {
         let (r, g, b, _a): (u8, u8, u8, u8) = self.into();
-        let rp = (u32::from(r)) << 16;
-        let gp = (u32::from(g)) << 8;
-        let bp = u32::from(b);
-        (rp | gp | bp)
+
+        u32::from_be_bytes([0, r, g, b])
     }
 }
 


### PR DESCRIPTION
I've got most of the API surface done here, but I've run into an issue. I've been following [this tutorial](https://webglfundamentals.org/webgl/lessons/webgl-render-to-texture.html) on rendering to a texture with WebGL (so the `Canvas` in this case is a Framebuffer wrapper, *NOT* the `<canvas>` element, which might be confusing but I reckon is closer to ggez).

Everything seems to be fine, I get no errors from WebGL anymore, so texture is properly initialized. I can bind the framebuffer to the gl context and it stops rendering stuff on main canvas, but rendering the image bound to the buffer leaves me with a blank image.

I'll look at this again tomorrow with fresh eyes.