### PR TITLE
ggez'ed key_up_event and key_down_event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
+bitflags = "1.1.0"
+rustc-hash = "1.0.1"
+lazy_static = "1.3.0"
 mint = "0.5"
 smart-default = "0.3"
 cgmath = { version = "0.16", features = ["mint"] }

--- a/src/event.rs
+++ b/src/event.rs
@@ -268,7 +268,9 @@ where
                 keymods |= KeyMods::LOGO;
             }
 
-            event.prevent_default();
+            if code.prevent_default() {
+                event.prevent_default();
+            }
 
             if !repeat {
                 input_handler.borrow_mut().handle_key_down(event.code());

--- a/src/event.rs
+++ b/src/event.rs
@@ -253,20 +253,7 @@ where
         move |event: KeyDownEvent| {
             let code = KeyCode::from(event.code());
             let repeat = event.repeat();
-            let mut keymods = KeyMods::NONE;
-
-            if event.shift_key() {
-                keymods |= KeyMods::SHIFT;
-            }
-            if event.ctrl_key() {
-                keymods |= KeyMods::CTRL;
-            }
-            if event.alt_key() {
-                keymods |= KeyMods::ALT;
-            }
-            if event.meta_key() {
-                keymods |= KeyMods::LOGO;
-            }
+            let keymods = KeyMods::from_event(&event);
 
             if code.prevent_default() {
                 event.prevent_default();
@@ -290,20 +277,7 @@ where
         move |event: KeyUpEvent| {
             let code = KeyCode::from(event.code());
             let repeat = event.repeat();
-            let mut keymods = KeyMods::NONE;
-
-            if event.shift_key() {
-                keymods |= KeyMods::SHIFT;
-            }
-            if event.ctrl_key() {
-                keymods |= KeyMods::CTRL;
-            }
-            if event.alt_key() {
-                keymods |= KeyMods::ALT;
-            }
-            if event.meta_key() {
-                keymods |= KeyMods::LOGO;
-            }
+            let keymods = KeyMods::from_event(&event);
 
             if !repeat {
                 input_handler.borrow_mut().handle_key_up(event.code());

--- a/src/event/keycode.rs
+++ b/src/event/keycode.rs
@@ -353,7 +353,7 @@ impl KeyCode {
     pub(crate) fn prevent_default(self) -> bool {
         use KeyCode::*;
         match self {
-            Space | PageUp | PageDown | Escape => true,
+            Space | PageUp | PageDown | Escape | Tab => true,
             _ => false,
         }
     }

--- a/src/event/keycode.rs
+++ b/src/event/keycode.rs
@@ -1,0 +1,350 @@
+use rustc_hash::FxHashMap;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref CODES: FxHashMap<&'static str, KeyCode> = {
+        use KeyCode::*;
+
+        let mut codes = FxHashMap::default();
+
+        codes.insert("Digit1", Key1);
+        codes.insert("Digit2", Key2);
+        codes.insert("Digit3", Key3);
+        codes.insert("Digit4", Key4);
+        codes.insert("Digit5", Key5);
+        codes.insert("Digit6", Key6);
+        codes.insert("Digit7", Key7);
+        codes.insert("Digit8", Key8);
+        codes.insert("Digit9", Key9);
+        codes.insert("Digit0", Key0);
+        codes.insert("KeyA", A);
+        codes.insert("KeyB", B);
+        codes.insert("KeyC", C);
+        codes.insert("KeyD", D);
+        codes.insert("KeyE", E);
+        codes.insert("KeyF", F);
+        codes.insert("KeyG", G);
+        codes.insert("KeyH", H);
+        codes.insert("KeyI", I);
+        codes.insert("KeyJ", J);
+        codes.insert("KeyK", K);
+        codes.insert("KeyL", L);
+        codes.insert("KeyM", M);
+        codes.insert("KeyN", N);
+        codes.insert("KeyO", O);
+        codes.insert("KeyP", P);
+        codes.insert("KeyQ", Q);
+        codes.insert("KeyR", R);
+        codes.insert("KeyS", S);
+        codes.insert("KeyT", T);
+        codes.insert("KeyU", U);
+        codes.insert("KeyV", V);
+        codes.insert("KeyW", W);
+        codes.insert("KeyX", X);
+        codes.insert("KeyY", Y);
+        codes.insert("KeyZ", Z);
+        codes.insert("Escape", Escape);
+        codes.insert("F1", F1);
+        codes.insert("F2", F2);
+        codes.insert("F3", F3);
+        codes.insert("F4", F4);
+        codes.insert("F5", F5);
+        codes.insert("F6", F6);
+        codes.insert("F7", F7);
+        codes.insert("F8", F8);
+        codes.insert("F9", F9);
+        codes.insert("F10", F10);
+        codes.insert("F11", F11);
+        codes.insert("F12", F12);
+        codes.insert("F13", F13);
+        codes.insert("F14", F14);
+        codes.insert("F15", F15);
+        codes.insert("F16", F16);
+        codes.insert("F17", F17);
+        codes.insert("F18", F18);
+        codes.insert("F19", F19);
+        codes.insert("F20", F20);
+        codes.insert("F21", F21);
+        codes.insert("F22", F22);
+        codes.insert("F23", F23);
+        codes.insert("F24", F24);
+        codes.insert("PrintScreen", Snapshot);
+        codes.insert("ScrollLock", Scroll);
+        codes.insert("Pause", Pause);
+        codes.insert("Insert", Insert);
+        codes.insert("Home", Home);
+        codes.insert("Delete", Delete);
+        codes.insert("End", End);
+        codes.insert("PageDown", PageDown);
+        codes.insert("PageUp", PageUp);
+        codes.insert("ArrowLeft", Left);
+        codes.insert("ArrowUp", Up);
+        codes.insert("ArrowRight", Right);
+        codes.insert("ArrowDown", Down);
+        codes.insert("Backspace", Back);
+        codes.insert("Enter", Return);
+        codes.insert("Space", Space);
+        // Compose,
+        // Caret,
+        codes.insert("NumLock", Numlock);
+        codes.insert("Numpad0", Numpad0);
+        codes.insert("Numpad1", Numpad1);
+        codes.insert("Numpad2", Numpad2);
+        codes.insert("Numpad3", Numpad3);
+        codes.insert("Numpad4", Numpad4);
+        codes.insert("Numpad5", Numpad5);
+        codes.insert("Numpad6", Numpad6);
+        codes.insert("Numpad7", Numpad7);
+        codes.insert("Numpad8", Numpad8);
+        codes.insert("Numpad9", Numpad9);
+        // AbntC1,
+        // AbntC2,
+        codes.insert("NumpadAdd", Add);
+        codes.insert("Quote", Apostrophe);
+        // Apps,
+        // At,
+        // Ax,
+        codes.insert("Backslash", Backslash);
+        // Calculator,
+        // Capital,
+        // Colon,
+        codes.insert("Comma", Comma);
+        codes.insert("Convert", Convert);
+        codes.insert("NumpadDecimal", Decimal);
+        codes.insert("NumpadDivide", Divide);
+        codes.insert("Equal", Equals);
+        codes.insert("Backquote", Grave);
+        codes.insert("KanaMode", Kana);
+        // Kanji,
+        codes.insert("AltLeft", LAlt);
+        codes.insert("BracketLeft", LBracket);
+        codes.insert("ControlLeft", LControl);
+        codes.insert("ShiftLeft", LShift);
+        codes.insert("MetaLeft", LWin);
+        codes.insert("OSLeft", LWin);
+        codes.insert("LaunchMail", Mail);
+        codes.insert("LaunchMediaPlayer", MediaSelect);
+        codes.insert("MediaSelect", MediaSelect);
+        codes.insert("MediaStop", MediaStop);
+        codes.insert("Minus", Minus);
+        codes.insert("NumpadMultiply", Multiply);
+        codes.insert("AudioVolumeMute", Mute);
+        // MyComputer,
+        // NavigateForward,
+        // NavigateBackward,
+        codes.insert("MediaTrackNext", NextTrack);
+        codes.insert("NonConvert", NoConvert);
+        codes.insert("NumpadComma", NumpadComma);
+        codes.insert("NumpadEnter", NumpadEnter);
+        codes.insert("NumpadEqual", NumpadEquals);
+        // OEM102,
+        codes.insert("Period", Period);
+        codes.insert("MediaPlayPause", PlayPause);
+        codes.insert("Power", Power);
+        codes.insert("MediaTrackPrevious", PrevTrack);
+        codes.insert("AltRight", RAlt);
+        codes.insert("BracketRight", RBracket);
+        codes.insert("ControlRight", RControl);
+        codes.insert("ShiftRight", RShift);
+        codes.insert("MetaRight", RWin);
+        codes.insert("OSRight", RWin);
+        codes.insert("Semicolon", Semicolon);
+        codes.insert("Slash", Slash);
+        codes.insert("Sleep", Sleep);
+        // Stop,
+        codes.insert("NumpadSubtract", Subtract);
+        // Sysrq,
+        codes.insert("Tab", Tab);
+        codes.insert("IntlRo", Underline);
+        // Unlabeled,
+        codes.insert("AudioVolumeDown", VolumeDown);
+        codes.insert("AudioVolumeUp", VolumeUp);
+        codes.insert("WakeUp", Wake);
+        codes.insert("BrowserBack", WebBack);
+        codes.insert("BrowserFavorites", WebFavorites);
+        codes.insert("BrowserForward", WebForward);
+        codes.insert("BrowserHome", WebHome);
+        codes.insert("BrowserRefresh", WebRefresh);
+        codes.insert("BrowserSearch", WebSearch);
+        codes.insert("BrowserStop", WebStop);
+        codes.insert("IntlYen", Yen);
+        codes.insert("Copy", Copy);
+        codes.insert("Paste", Paste);
+        codes.insert("Cut", Cut);
+        codes
+    };
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum KeyCode {
+    Key1,
+    Key2,
+    Key3,
+    Key4,
+    Key5,
+    Key6,
+    Key7,
+    Key8,
+    Key9,
+    Key0,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+    Escape,
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
+    F21,
+    F22,
+    F23,
+    F24,
+    Snapshot,
+    Scroll,
+    Pause,
+    Insert,
+    Home,
+    Delete,
+    End,
+    PageDown,
+    PageUp,
+    Left,
+    Up,
+    Right,
+    Down,
+    Back,
+    Return,
+    Space,
+    Compose,
+    Caret,
+    Numlock,
+    Numpad0,
+    Numpad1,
+    Numpad2,
+    Numpad3,
+    Numpad4,
+    Numpad5,
+    Numpad6,
+    Numpad7,
+    Numpad8,
+    Numpad9,
+    AbntC1,
+    AbntC2,
+    Add,
+    Apostrophe,
+    Apps,
+    At,
+    Ax,
+    Backslash,
+    Calculator,
+    Capital,
+    Colon,
+    Comma,
+    Convert,
+    Decimal,
+    Divide,
+    Equals,
+    Grave,
+    Kana,
+    Kanji,
+    LAlt,
+    LBracket,
+    LControl,
+    LShift,
+    LWin,
+    Mail,
+    MediaSelect,
+    MediaStop,
+    Minus,
+    Multiply,
+    Mute,
+    MyComputer,
+    NavigateForward,
+    NavigateBackward,
+    NextTrack,
+    NoConvert,
+    NumpadComma,
+    NumpadEnter,
+    NumpadEquals,
+    OEM102,
+    Period,
+    PlayPause,
+    Power,
+    PrevTrack,
+    RAlt,
+    RBracket,
+    RControl,
+    RShift,
+    RWin,
+    Semicolon,
+    Slash,
+    Sleep,
+    Stop,
+    Subtract,
+    Sysrq,
+    Tab,
+    Underline,
+    Unlabeled,
+    VolumeDown,
+    VolumeUp,
+    Wake,
+    WebBack,
+    WebFavorites,
+    WebForward,
+    WebHome,
+    WebRefresh,
+    WebSearch,
+    WebStop,
+    Yen,
+    Copy,
+    Paste,
+    Cut,
+}
+
+impl<S: AsRef<str>> From<S> for KeyCode {
+    fn from(code: S) -> KeyCode {
+        match CODES.get(code.as_ref()) {
+            Some(code) => *code,
+            None => KeyCode::Unlabeled
+        }
+    }
+}

--- a/src/event/keycode.rs
+++ b/src/event/keycode.rs
@@ -348,3 +348,13 @@ impl<S: AsRef<str>> From<S> for KeyCode {
         }
     }
 }
+
+impl KeyCode {
+    pub(crate) fn prevent_default(self) -> bool {
+        use KeyCode::*;
+        match self {
+            Space | PageUp | PageDown | Escape => true,
+            _ => false,
+        }
+    }
+}

--- a/src/goodies/scene.rs
+++ b/src/goodies/scene.rs
@@ -73,8 +73,8 @@ pub trait Scene<C> {
         _y: f32,
     ) {
     }
-    fn key_down_event(&mut self, _gameworld: &mut C, _ctx: &mut crate::Context, _key: &str) {}
-    fn key_up_event(&mut self, _gameworld: &mut C, _ctx: &mut crate::Context, _key: &str) {}
+    fn key_down_event(&mut self, _gameworld: &mut C, _ctx: &mut crate::Context, _key: crate::event::KeyCode) {}
+    fn key_up_event(&mut self, _gameworld: &mut C, _ctx: &mut crate::Context, _key: crate::event::KeyCode) {}
 
     /// Only used for human-readable convenience (or not at all, tbh)
     fn name(&self) -> &str;
@@ -266,21 +266,21 @@ impl<C> crate::event::EventHandler for SceneStack<C> {
         current_scene.mouse_button_up_event(&mut self.world, ctx, button, x, y);
     }
 
-    fn key_down_event(&mut self, ctx: &mut crate::Context, key: &str) {
+    fn key_down_event(&mut self, ctx: &mut crate::Context, keycode: crate::event::KeyCode, _keymods: crate::event::KeyMods, _repeat: bool) {
         let current_scene = &mut **self
             .scenes
             .last_mut()
             .expect("Tried to update empty scene stack");
 
-        current_scene.key_down_event(&mut self.world, ctx, key);
+        current_scene.key_down_event(&mut self.world, ctx, keycode);
     }
 
-    fn key_up_event(&mut self, ctx: &mut crate::Context, key: &str) {
+    fn key_up_event(&mut self, ctx: &mut crate::Context, keycode: crate::event::KeyCode, _keymods: crate::event::KeyMods) {
         let current_scene = &mut **self
             .scenes
             .last_mut()
             .expect("Tried to update empty scene stack");
 
-        current_scene.key_up_event(&mut self.world, ctx, key);
+        current_scene.key_up_event(&mut self.world, ctx, keycode);
     }
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use bitflags::bitflags;
 
 use super::input_handler::InputHandler;
 use crate::Context;
@@ -30,4 +31,14 @@ pub fn is_key_pressed(ctx: &Context, key: &str) -> bool {
 /// Checks if a key was pressed down on exectly this frame.
 pub fn is_key_down(ctx: &Context, key: &str) -> bool {
     ctx.keyboard_context.is_key_down(key)
+}
+
+bitflags! {
+    pub struct KeyMods: u8 {
+        const NONE = 0;
+        const SHIFT = 1 << 0;
+        const CTRL = 1 << 1;
+        const ALT = 1 << 2;
+        const LOGO = 1 << 3;
+    }
 }

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use bitflags::bitflags;
+use stdweb::web::event::IKeyboardEvent;
 
 use super::input_handler::InputHandler;
 use crate::Context;
@@ -40,5 +41,26 @@ bitflags! {
         const CTRL = 1 << 1;
         const ALT = 1 << 2;
         const LOGO = 1 << 3;
+    }
+}
+
+impl KeyMods {
+    pub(crate) fn from_event<E: IKeyboardEvent>(event: &E) -> Self {
+        let mut keymods = KeyMods::NONE;
+
+        if event.shift_key() {
+            keymods |= KeyMods::SHIFT;
+        }
+        if event.ctrl_key() {
+            keymods |= KeyMods::CTRL;
+        }
+        if event.alt_key() {
+            keymods |= KeyMods::ALT;
+        }
+        if event.meta_key() {
+            keymods |= KeyMods::LOGO;
+        }
+
+        keymods
     }
 }


### PR DESCRIPTION
+ Exposed `KeyCode` enum, which is a carbon copy of the one exposed in ggez.
+ Exposed `KeyMods` bitflags, should behave the same as in ggez.
+ Mapping browser codes to the enum using `lazy_static` HashMap (with the super fast rustc_hash).

Produced .wasm blob ended up 9-10kb bigger for me, which I reckon is acceptable.