### PR TITLE
Use keycodes in checking is_key_pressed/down

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -292,7 +292,7 @@ where
             }
 
             if !repeat {
-                input_handler.borrow_mut().handle_key_down(event.code());
+                input_handler.borrow_mut().handle_key_down(code);
             }
 
             state
@@ -312,7 +312,7 @@ where
             let keymods = KeyMods::from_event(&event);
 
             if !repeat {
-                input_handler.borrow_mut().handle_key_up(event.code());
+                input_handler.borrow_mut().handle_key_up(code);
             }
 
             state

--- a/src/event/keycode.rs
+++ b/src/event/keycode.rs
@@ -175,7 +175,7 @@ lazy_static! {
     };
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum KeyCode {
     Key1,
     Key2,

--- a/src/input/input_handler.rs
+++ b/src/input/input_handler.rs
@@ -5,6 +5,8 @@ use stdweb::web::event::MouseButton as WebMouseButton;
 use cgmath::Point2;
 use std::collections::HashSet;
 
+use crate::event::KeyCode;
+
 #[derive(Hash, Debug, Eq, PartialEq)]
 pub enum MouseButton {
     Left,
@@ -27,8 +29,8 @@ impl From<&WebMouseButton> for MouseButton {
 }
 
 pub struct InputHandler {
-    pub keys: HashSet<String>,
-    pub frame_keys: HashSet<String>,
+    pub keys: HashSet<KeyCode>,
+    pub frame_keys: HashSet<KeyCode>,
     pub mouse_position: Point2<f64>,
     pub mouse_keys: HashSet<MouseButton>,
     pub wheel: f32,
@@ -59,9 +61,9 @@ impl InputHandler {
         self.mouse_keys.remove(&MouseButton::from(&button));
     }
 
-    pub fn handle_key_down(&mut self, key: String) {
-        self.keys.insert(key.clone());
-        self.frame_keys.insert(key.clone());
+    pub fn handle_key_down(&mut self, keycode: KeyCode) {
+        self.keys.insert(keycode);
+        self.frame_keys.insert(keycode);
     }
 
     pub fn handle_end_frame(&mut self) {
@@ -69,20 +71,20 @@ impl InputHandler {
         self.wheel = 0.;
     }
 
-    pub fn handle_key_up(&mut self, key: String) {
-        self.keys.remove(&key);
+    pub fn handle_key_up(&mut self, keycode: KeyCode) {
+        self.keys.remove(&keycode);
     }
 
     pub fn handle_mouse_wheel(&mut self, delta_y: f64) {
         self.wheel = delta_y as f32;
     }
 
-    pub fn is_key_pressed(&self, key: &str) -> bool {
-        self.keys.contains(key)
+    pub fn is_key_pressed(&self, keycode: KeyCode) -> bool {
+        self.keys.contains(&keycode)
     }
 
-    pub fn is_key_down(&self, key: &str) -> bool {
-        self.frame_keys.contains(key)
+    pub fn is_key_down(&self, keycode: KeyCode) -> bool {
+        self.frame_keys.contains(&keycode)
     }
 
     pub fn is_mouse_key_down(&self, key: &MouseButton) -> bool {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -4,6 +4,7 @@ use bitflags::bitflags;
 use stdweb::web::event::IKeyboardEvent;
 
 use super::input_handler::InputHandler;
+use crate::event::KeyCode;
 use crate::Context;
 
 pub struct KeyboardContext {
@@ -15,23 +16,23 @@ impl KeyboardContext {
         KeyboardContext { input_handler }
     }
 
-    pub(crate) fn is_key_pressed(&self, key: &str) -> bool {
-        self.input_handler.borrow().is_key_pressed(key)
+    pub(crate) fn is_key_pressed(&self, keycode: KeyCode) -> bool {
+        self.input_handler.borrow().is_key_pressed(keycode)
     }
 
-    pub(crate) fn is_key_down(&self, key: &str) -> bool {
-        self.input_handler.borrow().is_key_down(key)
+    pub(crate) fn is_key_down(&self, keycode: KeyCode) -> bool {
+        self.input_handler.borrow().is_key_down(keycode)
     }
 }
 
 /// Checks if a key is currently pressed down.
-pub fn is_key_pressed(ctx: &Context, key: &str) -> bool {
-    ctx.keyboard_context.is_key_pressed(key)
+pub fn is_key_pressed(ctx: &Context, keycode: KeyCode) -> bool {
+    ctx.keyboard_context.is_key_pressed(keycode)
 }
 
 /// Checks if a key was pressed down on exectly this frame.
-pub fn is_key_down(ctx: &Context, key: &str) -> bool {
-    ctx.keyboard_context.is_key_down(key)
+pub fn is_key_down(ctx: &Context, keycode: KeyCode) -> bool {
+    ctx.keyboard_context.is_key_down(keycode)
 }
 
 bitflags! {


### PR DESCRIPTION
PR #17 switched the `key_down` and `key_up` events to use `KeyCode`s, but not `is_key_pressed`. This does just that :)