### PR TITLE
Fix missing mouse_button_down_event in event handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,11 @@ impl miniquad::EventHandlerFree for EventHandlerWrapper {
         );
     }
 
+    fn mouse_button_down_event(&mut self, button: miniquad::MouseButton, x: f32, y: f32) {
+        self.event_handler
+            .mouse_button_down_event(&mut self.context, button.into(), x, y);
+    }
+
     fn mouse_button_up_event(&mut self, button: miniquad::MouseButton, x: f32, y: f32) {
         self.event_handler
             .mouse_button_up_event(&mut self.context, button.into(), x, y);


### PR DESCRIPTION
I noticed no mouse down events getting through to my game, and it turned out the `mouse_button_down_event` was missing in the `miniquad::EventHandlerFree` implementation in lib.rs.
This pull request fixes this problem by introducing the missing `mouse_button_down_event`.