### PR TITLE
Add Conf::physical_root_dir

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -37,7 +37,7 @@ impl event::EventHandler for App {
         let strings = [("AAija", 86.), ("jjjjj", 100.), ("i", 50.)];
         let vertical_spacing = 150.;
 
-        for (i, (string, scale)) in strings.into_iter().enumerate() {
+        for (i, (string, scale)) in strings.iter().enumerate() {
             let text_y = 50. + (*scale + vertical_spacing) * i as f32;
             let text = Text::new((*string, self.fancy_font, *scale));
             let dimensions = text.dimensions(ctx);

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[derive(Debug)]
 pub enum Cache {
     /// No preloading at all, filesystem::open will always panic.
@@ -23,6 +25,9 @@ pub enum Loading {
 pub struct Conf {
     pub cache: Cache,
     pub loading: Loading,
+
+    /// `Filesystem::open` will try to read from this dir if there's no such file in the cache.
+    pub physical_root_dir: Option<PathBuf>,
 }
 
 impl Default for Conf {
@@ -30,6 +35,7 @@ impl Default for Conf {
         Conf {
             cache: Cache::No,
             loading: Loading::No,
+            physical_root_dir: None,
         }
     }
 }

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -25,8 +25,9 @@ pub enum Loading {
 pub struct Conf {
     pub cache: Cache,
     pub loading: Loading,
-
     /// `Filesystem::open` will try to read from this dir if there's no such file in the cache.
+    ///
+    /// Note that this won't work on platforms where `std::fs` is unavailable, like WASM.
     pub physical_root_dir: Option<PathBuf>,
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::{
-    conf::{Cache, Conf},
+    conf::Conf,
     filesystem::Filesystem,
     graphics,
     input::{input_handler::InputHandler, KeyboardContext, MouseContext},
@@ -20,15 +20,10 @@ pub struct Context {
 
 impl Context {
     pub(crate) fn new(mut quad_ctx: miniquad::Context, conf: Conf) -> Context {
-        let tar = if let Cache::Tar(tar) = conf.cache {
-            tar
-        } else {
-            unimplemented!("Only tar archive filesystem supported")
-        };
         let input_handler = Rc::new(RefCell::new(InputHandler::new()));
 
         Context {
-            filesystem: Filesystem::new(&tar),
+            filesystem: Filesystem::new(&conf),
             gfx_context: graphics::GraphicsContext::new(&mut quad_ctx),
             mouse_context: MouseContext::new(input_handler.clone()),
             keyboard_context: KeyboardContext::new(input_handler.clone()),

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -64,6 +64,7 @@ impl Filesystem {
             path = path::PathBuf::from(stripped);
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(ref root_path) = self.root {
             if let Ok(buf) = std::fs::read(root_path.join(&path)) {
                 let bytes = io::Cursor::new(buf);


### PR DESCRIPTION
This PR adds an optional `physical_root_dir` field to `Conf` to allow reading files from the file system more-or-less like it's done in ggez. What do you think?