### PR TITLE
Conf::physical_root_dir: Fix cfg(not(wasm))

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -65,11 +65,13 @@ impl Filesystem {
         }
 
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(ref root_path) = self.root {
-            if let Ok(buf) = std::fs::read(root_path.join(&path)) {
-                let bytes = io::Cursor::new(buf);
-                return Ok(File { bytes });
-            };
+        {
+            if let Some(ref root_path) = self.root {
+                if let Ok(buf) = std::fs::read(root_path.join(&path)) {
+                    let bytes = io::Cursor::new(buf);$
+                    return Ok(File { bytes });
+                }
+            }
         }
 
         if !self.files.contains_key(&path) {


### PR DESCRIPTION
Fixes this:

```
error: attributes are not yet allowed on `if` expressions
  --> /home/ozkriff/.cargo/git/checkouts/good-web-game-7310e1c1dcac66c0/5dcafa1/src/filesystem.rs:67:9
   |
67 |         #[cfg(not(target_arch = "wasm32"))]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

Follow-up on https://github.com/not-fl3/good-web-game/pull/36, sorry