### PR TITLE
Fix SpriteBatch panic when rendering with 1 DrawParam

### DIFF
--- a/src/graphics/spritebatch.rs
+++ b/src/graphics/spritebatch.rs
@@ -35,7 +35,7 @@ impl SpriteBatch {
             image: RefCell::new(image),
             sprites: vec![],
             blend_mode: None,
-            gpu_sprites: RefCell::new(vec![InstanceAttributes::default()]),
+            gpu_sprites: RefCell::new(vec![]),
         }
     }
 


### PR DESCRIPTION
When rendering with 1 DrawParam

graphics/SpriteBatch.rs
`122: image.bindings.vertex_buffers[1].update(&mut ctx.quad_ctx, &gpu_sprites[0..self.sprites.len()]);`

vertex_buffers[1] is out of bounds because it is never setup.

The check that sets it up (should always happend first draw call I assume...):
`85: if self.sprites.len() > gpu_sprites.len() {`
fails, because, well in the case of one sprite, checked against gpu_sprites.len()
which always gets instansiated with one element.

